### PR TITLE
Fast loss

### DIFF
--- a/examples/sample.py
+++ b/examples/sample.py
@@ -122,9 +122,10 @@ else:
                           print_every=10, expt_dir=opt.expt_dir)
 
     seq2seq = t.train(seq2seq, train,
-            num_epochs=4, dev_data=dev,
-            optimizer=optimizer,
-            resume=opt.resume)
+                      num_epochs=6, dev_data=dev,
+                      optimizer=optimizer,
+                      teacher_forcing_ratio=0,
+                      resume=opt.resume)
 
 predictor = Predictor(seq2seq, input_vocab, output_vocab)
 

--- a/examples/sample.py
+++ b/examples/sample.py
@@ -124,7 +124,7 @@ else:
     seq2seq = t.train(seq2seq, train,
                       num_epochs=6, dev_data=dev,
                       optimizer=optimizer,
-                      teacher_forcing_ratio=0,
+                      teacher_forcing_ratio=0.5,
                       resume=opt.resume)
 
 predictor = Predictor(seq2seq, input_vocab, output_vocab)

--- a/seq2seq/evaluator/evaluator.py
+++ b/seq2seq/evaluator/evaluator.py
@@ -44,15 +44,7 @@ class Evaluator(object):
             decoder_outputs, decoder_hidden, other = model(input_variables, input_lengths.tolist(), target_variables)
 
             # Evaluation
-            lengths = other['length']
-            for b in range(target_variables.size(0)):
-                # Batch wise loss
-                batch_target = target_variables[b, 1:]
-                batch_len = min(lengths[b], target_variables.size(1) - 1)
-                # Crop output and target to batch length
-                batch_output = torch.stack([output[b] for output in decoder_outputs[:batch_len]])
-                batch_target = batch_target[:batch_len]
-                # Evaluate loss
-                loss.eval_batch(batch_output, batch_target)
+            for step, step_output in enumerate(decoder_outputs):
+                loss.eval_batch(step_output.view(target_variables.size(0), -1), target_variables[:, step + 1])
 
         return loss.get_loss()

--- a/seq2seq/evaluator/predictor.py
+++ b/seq2seq/evaluator/predictor.py
@@ -33,13 +33,10 @@ class Predictor(object):
         """
         src_id_seq = Variable(torch.LongTensor([self.src_vocab.stoi[tok] for tok in src_seq]),
                               volatile=True).view(1, -1)
-        decoder_kick = Variable(torch.LongTensor([self.tgt_vocab.stoi['<sos>']]),
-                                volatile=True).view(1, -1)
         if torch.cuda.is_available():
             src_id_seq = src_id_seq.cuda()
-            decoder_kick = decoder_kick.cuda()
 
-        softmax_list, _, other = self.model(src_id_seq, [len(src_seq)], decoder_kick)
+        softmax_list, _, other = self.model(src_id_seq, [len(src_seq)])
         length = other['length'][0]
 
         tgt_id_seq = [other['sequence'][di][0].data[0] for di in range(length)]

--- a/seq2seq/models/DecoderRNN.py
+++ b/seq2seq/models/DecoderRNN.py
@@ -123,18 +123,19 @@ class DecoderRNN(BaseRNN):
                     batch_size = encoder_hidden.size(1)
 
         if inputs is None:
-            decoder_input = Variable(torch.LongTensor([self.sos_id]),
+            inputs = Variable(torch.LongTensor([self.sos_id]),
                                     volatile=True).view(batch_size, -1)
+            max_length = self.max_length
         else:
-            decoder_input = inputs[:, 0].unsqueeze(1)
-            inputs = None if inputs.size(1) == 1 else inputs[:, 1:]
+            max_length = inputs.size(1) - 1 # minus the start of sequence symbol
+
         decoder_hidden = encoder_hidden
 
         use_teacher_forcing = True if random.random() < teacher_forcing_ratio else False
 
         decoder_outputs = []
         sequence_symbols = []
-        lengths = np.array([self.max_length] * batch_size)
+        lengths = np.array([max_length] * batch_size)
 
         def decode(step, step_output, step_attn):
             decoder_outputs.append(step_output)
@@ -153,8 +154,7 @@ class DecoderRNN(BaseRNN):
         # Manual unrolling is used to support random teacher forcing.
         # If teacher_forcing_ratio is True or False instead of a probability, the unrolling can be done in graph
         if use_teacher_forcing:
-            decoder_input = torch.cat([decoder_input, inputs], dim=1)
-            decoder_output, decoder_hidden, attn = self.forward_step(decoder_input, decoder_hidden, encoder_outputs,
+            decoder_output, decoder_hidden, attn = self.forward_step(inputs, decoder_hidden, encoder_outputs,
                                                                      function=function)
 
             for di in range(inputs.size(1)):
@@ -162,7 +162,8 @@ class DecoderRNN(BaseRNN):
                 step_attn = attn[:, di, :]
                 decode(di, step_output, step_attn)
         else:
-            for di in range(self.max_length):
+            decoder_input = inputs[:, 0].unsqueeze(1)
+            for di in range(max_length):
                 decoder_output, decoder_hidden, step_attn = self.forward_step(decoder_input, decoder_hidden, encoder_outputs,
                                                                          function=function)
                 step_output = decoder_output.squeeze(1)

--- a/seq2seq/models/DecoderRNN.py
+++ b/seq2seq/models/DecoderRNN.py
@@ -154,10 +154,11 @@ class DecoderRNN(BaseRNN):
         # Manual unrolling is used to support random teacher forcing.
         # If teacher_forcing_ratio is True or False instead of a probability, the unrolling can be done in graph
         if use_teacher_forcing:
-            decoder_output, decoder_hidden, attn = self.forward_step(inputs, decoder_hidden, encoder_outputs,
+            decoder_input = inputs[:, :-1]
+            decoder_output, decoder_hidden, attn = self.forward_step(decoder_input, decoder_hidden, encoder_outputs,
                                                                      function=function)
 
-            for di in range(inputs.size(1)):
+            for di in range(decoder_output.size(1)):
                 step_output = decoder_output[:, di, :]
                 step_attn = attn[:, di, :]
                 decode(di, step_output, step_attn)

--- a/seq2seq/trainer/supervised_trainer.py
+++ b/seq2seq/trainer/supervised_trainer.py
@@ -55,16 +55,8 @@ class SupervisedTrainer(object):
                                                        teacher_forcing_ratio=teacher_forcing_ratio)
         # Get loss
         loss.reset()
-        lengths = other['length']
-        for batch in range(target_variable.size(0)):
-            # Batch wise loss
-            batch_target = target_variable[batch, 1:]
-            batch_len = min(lengths[batch], target_variable.size(1) - 1)
-            # Crop output and target to batch length
-            batch_output = torch.stack([output[batch] for output in decoder_outputs[:batch_len]])
-            batch_target = batch_target[:batch_len]
-            # Evaluate loss
-            loss.eval_batch(batch_output, batch_target)
+        for step, step_output in enumerate(decoder_outputs):
+            loss.eval_batch(step_output.contiguous().view(target_variable.size(0), -1), target_variable[:, step + 1])
         # Backward propagation
         model.zero_grad()
         loss.backward()

--- a/seq2seq/trainer/supervised_trainer.py
+++ b/seq2seq/trainer/supervised_trainer.py
@@ -56,7 +56,8 @@ class SupervisedTrainer(object):
         # Get loss
         loss.reset()
         for step, step_output in enumerate(decoder_outputs):
-            loss.eval_batch(step_output.contiguous().view(target_variable.size(0), -1), target_variable[:, step + 1])
+            batch_size = target_variable.size(0)
+            loss.eval_batch(step_output.contiguous().view(batch_size, -1), target_variable[:, step + 1])
         # Backward propagation
         model.zero_grad()
         loss.backward()


### PR DESCRIPTION
Addressed #34 .

Running for 20 epochs, the new loss calculate is 40% faster than the current one with similar accuracy (accuracy is less meaningful due to the size of dataset and number of epoches).  
```
Branch             Time (sec)       Train-PPL          Dev-PPL
develop            468              364                488
fast-loss          285              281                415
```