### PR TITLE
attention is not required when only using teacher forcing in decoder

### DIFF
--- a/seq2seq/models/DecoderRNN.py
+++ b/seq2seq/models/DecoderRNN.py
@@ -166,7 +166,7 @@ class DecoderRNN(BaseRNN):
 
             for di in range(decoder_output.size(1)):
                 step_output = decoder_output[:, di, :]
-                if attn:
+                if attn is not None:
                     step_attn = attn[:, di, :]
                 else:
                     step_attn = None

--- a/seq2seq/models/DecoderRNN.py
+++ b/seq2seq/models/DecoderRNN.py
@@ -166,7 +166,10 @@ class DecoderRNN(BaseRNN):
 
             for di in range(decoder_output.size(1)):
                 step_output = decoder_output[:, di, :]
-                step_attn = attn[:, di, :]
+                if attn:
+                    step_attn = attn[:, di, :]
+                else:
+                    step_attn = None
                 decode(di, step_output, step_attn)
         else:
             decoder_input = inputs[:, 0].unsqueeze(1)


### PR DESCRIPTION
#89 Fixes this bug: when using teacher forcing but not attention in decoder, an error will be thrown saying attention is not subscriptable because it is None.