### PR TITLE
add contiguous call to tensor in decoder

### DIFF
--- a/seq2seq/models/DecoderRNN.py
+++ b/seq2seq/models/DecoderRNN.py
@@ -102,7 +102,7 @@ class DecoderRNN(BaseRNN):
         if self.use_attention:
             output, attn = self.attention(output, encoder_outputs)
 
-        predicted_softmax = function(self.out(output.view(-1, self.hidden_size))).view(batch_size, output_size, -1)
+        predicted_softmax = function(self.out(output.contiguous().view(-1, self.hidden_size))).view(batch_size, output_size, -1)
         return predicted_softmax, hidden, attn
 
     def forward(self, inputs=None, encoder_hidden=None, encoder_outputs=None,


### PR DESCRIPTION
when attention is turned off, pytorch (well, 0.4 at least) gets angry about calling view on a non-contiguous tensor

(I'm using the model from within [ParlAI](https://github.com/facebookresearch/ParlAI/), so I ran `python examples/train_model.py -t babi:task10k:1 --dict-file /tmp/dict_babi:task10k:1 -bs 32 -m ibm_seq2seq -att False`)