### PR TITLE
Various cleanups to SupervisedTrainer

### DIFF
--- a/examples/sample.py
+++ b/examples/sample.py
@@ -68,15 +68,18 @@ def sample(
 
     ## Training
     ```shell
-    ./examples/sample.py $TRAIN_SRC $TRAIN_TGT $DEV_SRC $DEV_TGT -expt $EXPT_PATH
+    $ ./examples/sample.py $TRAIN_SRC $TRAIN_TGT $DEV_SRC $DEV_TGT -expt
+    $EXPT_PATH
     ```
     ## Resuming from the latest checkpoint of the experiment
     ```shell
-    ./examples/sample.py $TRAIN_SRC $TRAIN_TGT $DEV_SRC $DEV_TGT -expt $EXPT_PATH -r
+    $ ./examples/sample.py $TRAIN_SRC $TRAIN_TGT $DEV_SRC $DEV_TGT -expt
+    $EXPT_PATH -r
     ```
     ## Resuming from a specific checkpoint
     ```shell
-    python examples/sample.py $TRAIN_SRC $TRAIN_TGT $DEV_SRC $DEV_TGT -expt $EXPT_PATH -c $CHECKPOINT_DIR
+    $ python examples/sample.py $TRAIN_SRC $TRAIN_TGT $DEV_SRC $DEV_TGT -expt
+    $EXPT_PATH -c $CHECKPOINT_DIR
     ```
     """
     logging.basicConfig(
@@ -161,17 +164,17 @@ def train_model(
     # Train
     trainer = SupervisedTrainer(
         loss=loss,
-        batch_size=32,
+        batch_size=512,
         checkpoint_every=50,
         print_every=10,
-        expt_dir=experiment_directory,
+        experiment_directory=experiment_directory,
     )
     start = time.clock()
     try:
         seq2seq = trainer.train(
             seq2seq,
             train,
-            num_epochs=1,
+            n_epochs=2,
             dev_data=dev,
             optimizer=optimizer,
             teacher_forcing_ratio=0.5,

--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -82,10 +82,10 @@ else:
     # train
     t = SupervisedTrainer(loss=loss, batch_size=32,
                           checkpoint_every=50,
-                          print_every=10, expt_dir=opt.expt_dir)
+                          print_every=10, experiment_directory=opt.expt_dir)
     start = time.clock()
     seq2seq = t.train(seq2seq, train,
-                      num_epochs=6, dev_data=dev,
+                      n_epochs=6, dev_data=dev,
                       optimizer=optimizer,
                       teacher_forcing_ratio=0.5,
                       resume=opt.resume)

--- a/seq2seq/trainer/supervised_trainer.py
+++ b/seq2seq/trainer/supervised_trainer.py
@@ -14,66 +14,134 @@ from seq2seq.loss import NLLLoss
 from seq2seq.optim import Optimizer
 from seq2seq.util import Checkpoint
 
+logger = logging.getLogger(__name__)
+
+
 class SupervisedTrainer(object):
-    """ The SupervisedTrainer class helps in setting up a training framework in a
-    supervised setting.
+    """The SupervisedTrainer class helps in setting up a training framework
+    in a supervised setting.
 
     Args:
-        expt_dir (optional, str): experiment Directory to store details of the experiment,
-            by default it makes a folder in the current directory to store the details (default: `experiment`).
-        loss (seq2seq.loss.loss.Loss, optional): loss for training, (default: seq2seq.loss.NLLLoss)
-        batch_size (int, optional): batch size for experiment, (default: 64)
-        checkpoint_every (int, optional): number of batches to checkpoint after, (default: 100)
+        experiment_directory (optional, str): directory to store experiments in
+        loss (seq2seq.loss.loss.Loss, optional): loss for training
+        batch_size (int, optional): batch size for experiment
+        checkpoint_every (int, optional): number of batches to checkpoint after
     """
-    def __init__(self, expt_dir='experiment', loss=NLLLoss(), batch_size=64,
-                 random_seed=None, checkpoint_every=100, print_every=100):
-        self._trainer = "Simple Trainer"
-        self.random_seed = random_seed
+    def __init__(
+            self,
+            experiment_directory='./experiment',
+            loss=None,
+            batch_size=64,
+            random_seed=None,
+            checkpoint_every=100,
+            print_every=100,
+    ):
+        if loss is None:
+            loss = NLLLoss()
         if random_seed is not None:
             random.seed(random_seed)
             torch.manual_seed(random_seed)
+
         self.loss = loss
         self.evaluator = Evaluator(loss=self.loss, batch_size=batch_size)
         self.optimizer = None
         self.checkpoint_every = checkpoint_every
         self.print_every = print_every
-
-        if not os.path.isabs(expt_dir):
-            expt_dir = os.path.join(os.getcwd(), expt_dir)
-        self.expt_dir = expt_dir
-        if not os.path.exists(self.expt_dir):
-            os.makedirs(self.expt_dir)
         self.batch_size = batch_size
+        self.experiment_directory = experiment_directory
 
-        self.logger = logging.getLogger(__name__)
+        if not os.path.exists(self.experiment_directory):
+            os.makedirs(self.experiment_directory)
 
-    def _train_batch(self, batch, model, teacher_forcing_ratio, dataset):
-        loss = self.loss
-        # Forward propagation
-        decoder_outputs, _, _ = model(batch, dataset=dataset, 
-                                teacher_forcing_ratio=teacher_forcing_ratio)
-        # Get loss
-        loss.reset()
-        loss.eval_batch(decoder_outputs, batch)
-        # Backward propagation
-        model.zero_grad()
-        loss.backward()
-        self.optimizer.step()
+    def train(
+            self,
+            model,
+            data,
+            n_epochs=5,
+            resume=False,
+            dev_data=None,
+            optimizer=None,
+            teacher_forcing_ratio=0,
+    ):
+        """Train a given model.
 
-        return loss.get_loss()
+        Args:
+            model (seq2seq.models): model to run training on. If resume=True,
+                it will be overwritten by the model loaded from the latest
+                checkpoint
+            data (seq2seq.dataset.dataset.Dataset): dataset object to train on
+            n_epochs (int): number of epochs to run
+            resume(bool): resume training with the latest checkpoint
+            dev_data (seq2seq.dataset.dataset.Dataset): dev Dataset
+            optimizer (seq2seq.optim.Optimizer): optimizer for training
+            teacher_forcing_ratio (float): teaching forcing ratio
+        Returns:
+            model (seq2seq.models): trained model.
+        """
+        if resume:
+            latest_checkpoint_path = Checkpoint.get_latest_checkpoint(
+                self.experiment_directory)
+            resume_checkpoint = Checkpoint.load(latest_checkpoint_path)
+            model = resume_checkpoint.model
+            self.optimizer = resume_checkpoint.optimizer
 
-    def _train_epoches(self, data, model, n_epochs, start_epoch, start_step,
-                       dev_data=None, teacher_forcing_ratio=0):
-        log = self.logger
-        print_loss_total = 0  # Reset every print_every
-        epoch_loss_total = 0  # Reset every epoch
+            # A work-around to set optimizing parameters properly
+            resume_optim = self.optimizer.optimizer
+            defaults = resume_optim.param_groups[0]
+            defaults.pop('params', None)
+            defaults.pop('initial_lr', None)
+            self.optimizer.optimizer = resume_optim.__class__(
+                model.parameters(), **defaults)
 
+            start_epoch = resume_checkpoint.epoch
+            step = resume_checkpoint.step
+        else:
+            start_epoch = 1
+            step = 0
+            if optimizer is None:
+                optimizer = Optimizer(
+                    optim.Adam(model.parameters()), max_grad_norm=5)
+            self.optimizer = optimizer
+
+        logger.info(
+            'Optimizer: %s, Scheduler: %s',
+            self.optimizer.optimizer,
+            self.optimizer.scheduler,
+        )
+
+        self._train_epochs(
+            data,
+            model,
+            n_epochs,
+            start_epoch,
+            step,
+            dev_data=dev_data,
+            teacher_forcing_ratio=teacher_forcing_ratio,
+        )
+        return model
+
+    def _train_epochs(
+            self,
+            data,
+            model,
+            n_epochs,
+            start_epoch,
+            start_step,
+            dev_data=None,
+            teacher_forcing_ratio=0,
+    ):
+        print_loss_total = epoch_loss_total = 0
         device = None if torch.cuda.is_available() else -1
+
         batch_iterator = torchtext.data.BucketIterator(
-            dataset=data, batch_size=self.batch_size,
-            sort=False, sort_within_batch=True,
+            dataset=data,
+            batch_size=self.batch_size,
+            sort=False,
+            sort_within_batch=True,
             sort_key=lambda x: len(x.src),
-            device=device, repeat=False)
+            device=device,
+            repeat=False,
+        )
 
         steps_per_epoch = len(batch_iterator)
         total_steps = steps_per_epoch * n_epochs
@@ -81,14 +149,14 @@ class SupervisedTrainer(object):
         step = start_step
         step_elapsed = 0
         for epoch in range(start_epoch, n_epochs + 1):
-            log.debug("Epoch: %d, Step: %d" % (epoch, step))
+            logger.debug('Epoch: %d, Step: %d', epoch, step)
 
-            batch_generator = batch_iterator.__iter__()
-            # consuming seen batches from previous training
+            batch_generator = iter(batch_iterator)
+            # Consuming seen batches from previous training
             for _ in range((epoch - 1) * steps_per_epoch, step):
                 next(batch_generator)
 
-            model.train(True)
+            model.train()
             progress_bar = tqdm(
                 batch_generator,
                 total=steps_per_epoch,
@@ -98,13 +166,17 @@ class SupervisedTrainer(object):
                 step += 1
                 step_elapsed += 1
 
-                loss = self._train_batch(batch, model, teacher_forcing_ratio, data)
-
-                # Record average loss
+                loss = self._train_batch(
+                    batch,
+                    model,
+                    teacher_forcing_ratio,
+                    data,
+                )
                 print_loss_total += loss
                 epoch_loss_total += loss
 
-                if step % self.print_every == 0 and step_elapsed > self.print_every:
+                if step % self.print_every == 0 \
+                   and step_elapsed > self.print_every:
                     print_loss_avg = print_loss_total / self.print_every
                     print_loss_total = 0
                     progress_bar.set_description('Train {}: {:.4f}'.format(
@@ -114,70 +186,47 @@ class SupervisedTrainer(object):
 
                 # Checkpoint
                 if step % self.checkpoint_every == 0 or step == total_steps:
-                    Checkpoint(model=model,
-                               optimizer=self.optimizer,
-                               epoch=epoch, step=step,
-                               input_vocab=data.fields[seq2seq.src_field_name].vocab,
-                               output_vocab=data.fields[seq2seq.tgt_field_name].vocab).save(self.expt_dir)
+                    Checkpoint(
+                        model=model,
+                        optimizer=self.optimizer,
+                        epoch=epoch, step=step,
+                        input_vocab=data.fields[seq2seq.src_field_name].vocab,
+                        output_vocab=data.fields[seq2seq.tgt_field_name].vocab,
+                    ).save(self.experiment_directory)
 
-            if step_elapsed == 0: continue
+            if step_elapsed == 0:
+                continue
 
-            epoch_loss_avg = epoch_loss_total / min(steps_per_epoch, step - start_step)
+            epoch_loss_avg = epoch_loss_total / min(
+                steps_per_epoch, step - start_step)
             epoch_loss_total = 0
-            log_msg = "Finished epoch %d: Train %s: %.4f" % (epoch, self.loss.name, epoch_loss_avg)
+            log_msg = 'Finished epoch {:d}: Train {}: {:.4f}'.format(
+                epoch, self.loss.name, epoch_loss_avg)
             if dev_data is not None:
                 dev_loss, accuracy = self.evaluator.evaluate(model, dev_data)
                 self.optimizer.update(dev_loss, epoch)
-                log_msg += ", Dev %s: %.4f, Accuracy: %.4f" % (self.loss.name, dev_loss, accuracy)
-                model.train(mode=True)
+                log_msg += ', Dev {}: {:.4f}, Accuracy: {:.4f}'.format(
+                    self.loss.name, dev_loss, accuracy)
+                model.train()
             else:
                 self.optimizer.update(epoch_loss_avg, epoch)
 
-            log.info(log_msg)
+            logger.info(log_msg)
 
-    def train(self, model, data, num_epochs=5, resume=False, 
-              dev_data=None, optimizer=None, teacher_forcing_ratio=0):
-        """ Run training for a given model.
+    def _train_batch(self, batch, model, teacher_forcing_ratio, dataset):
+        # Forward propagation
+        output, _, _ = model(
+            batch,
+            dataset=dataset,
+            teacher_forcing_ratio=teacher_forcing_ratio,
+        )
+        # Get loss
+        self.loss.reset()
+        self.loss.eval_batch(output, batch)
 
-        Args:
-            model (seq2seq.models): model to run training on, if `resume=True`, it would be
-               overwritten by the model loaded from the latest checkpoint.
-            data (seq2seq.dataset.dataset.Dataset): dataset object to train on
-            num_epochs (int, optional): number of epochs to run (default 5)
-            resume(bool, optional): resume training with the latest checkpoint, (default False)
-            dev_data (seq2seq.dataset.dataset.Dataset, optional): dev Dataset (default None)
-            optimizer (seq2seq.optim.Optimizer, optional): optimizer for training
-               (default: Optimizer(pytorch.optim.Adam, max_grad_norm=5))
-            teacher_forcing_ratio (float, optional): teaching forcing ratio (default 0)
-        Returns:
-            model (seq2seq.models): trained model.
-        """
-        # If training is set to resume
-        if resume:
-            latest_checkpoint_path = Checkpoint.get_latest_checkpoint(self.expt_dir)
-            resume_checkpoint = Checkpoint.load(latest_checkpoint_path)
-            model = resume_checkpoint.model
-            self.optimizer = resume_checkpoint.optimizer
+        # Backward propagation
+        model.zero_grad()
+        self.loss.backward()
+        self.optimizer.step()
 
-            # A walk around to set optimizing parameters properly
-            resume_optim = self.optimizer.optimizer
-            defaults = resume_optim.param_groups[0]
-            defaults.pop('params', None)
-            defaults.pop('initial_lr', None)
-            self.optimizer.optimizer = resume_optim.__class__(model.parameters(), **defaults)
-
-            start_epoch = resume_checkpoint.epoch
-            step = resume_checkpoint.step
-        else:
-            start_epoch = 1
-            step = 0
-            if optimizer is None:
-                optimizer = Optimizer(optim.Adam(model.parameters()), max_grad_norm=5)
-            self.optimizer = optimizer
-
-        self.logger.info("Optimizer: %s, Scheduler: %s" % (self.optimizer.optimizer, self.optimizer.scheduler))
-
-        self._train_epoches(data, model, num_epochs,
-                            start_epoch, step, dev_data=dev_data,
-                            teacher_forcing_ratio=teacher_forcing_ratio)
-        return model
+        return self.loss.get_loss()

--- a/tests/test_supervised_trainer.py
+++ b/tests/test_supervised_trainer.py
@@ -32,7 +32,7 @@ class TestSupervisedTrainer(unittest.TestCase):
         start_epoch = 1
         steps_per_epoch = 7
         step = 3
-        trainer._train_epoches(self.dataset, mock_model, n_epoches, start_epoch, step)
+        trainer._train_epochs(self.dataset, mock_model, n_epoches, start_epoch, step)
 
         self.assertEqual(steps_per_epoch - step, mock_func.call_count)
 
@@ -47,7 +47,7 @@ class TestSupervisedTrainer(unittest.TestCase):
         n_epoches = 1
         start_epoch = 1
         step = 7
-        trainer._train_epoches(self.dataset, mock_model, n_epoches, start_epoch, step)
+        trainer._train_epochs(self.dataset, mock_model, n_epoches, start_epoch, step)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Enforce the standard line length of 80 characters
- Propagate rename of `expt_dir` to `experiment_directory`
- Change `num_epochs` to `n_epochs`
- Move `logging.getLogger` to the global scope as it isn't class-specific plus it is more standard to have it there
- Change long argument lists to one-per-line so that it is easier to read
- Do not convert `experiment_directory` to an absolute path if it isn't one as doing this has no effect on the outcome of the program
- Specifying the mode in `model.train(mode=True)` is redundant so changed these calls to just `model.train()`
- Reorder functions so that the higher-level ones appear earlier in the code, ie. `train` --> `train_epochs` --> `train_batch`
- Rename `train_epoches` to `train_epochs` (typo)
- Remove the default values from docstrings because 1) it is clutter 2) it is easy to see the default arguments by the method string 3) default arguments are often changed so it won't take long for the docstring to lie about the default values. They are better left out
- Tools like Sentry require that logging messages look like `self.logger.info("Optimizer: %s, Scheduler: %s", self.optimizer.optimizer, self.optimizer.scheduler)` instead of `self.logger.info("Optimizer: %s, Scheduler: %s" % (self.optimizer.optimizer, self.optimizer.scheduler))`. If this weren't the case, I would change to the better `.format()` method
- Replace `NLLLoss()` as a default argument with `None`. Mutable objects should never be set as default arguments because this causes bugs. A common beginner programming error is setting a default argument like `def foo(lst=[])` instead of `def foo(lst=None): if lst is None: lst = []`. [Here](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments) for more information
- Remove unused attributes `self.random_seed` and `self._trainer` (a string name)