### PR TITLE
Fix hidden size when bidirectional is set to False

### DIFF
--- a/examples/sample.py
+++ b/examples/sample.py
@@ -209,7 +209,7 @@ def initialize_model(
     decoder = DecoderRNN(
         len(output_vocab),
         max_len,
-        hidden_size * 2 if bidirectional else 1,
+        hidden_size * (2 if bidirectional else 1),
         dropout_p=dropout_p,
         use_attention=True,
         bidirectional=bidirectional,


### PR DESCRIPTION
## Why 
When bidirectional is set to false, the hidden size of the decoder is set to be 1 and it causes `RuntimeError: Expected hidden size (1, 16, 1), got (1, 16, 256)`

## How
Change it to hidden_size, the same as encoder