### PR TITLE
replace torch.nn.functional.tanh (depreciated)

### DIFF
--- a/seq2seq/models/attention.py
+++ b/seq2seq/models/attention.py
@@ -67,6 +67,6 @@ class Attention(nn.Module):
         # concat -> (batch, out_len, 2*dim)
         combined = torch.cat((mix, output), dim=2)
         # output -> (batch, out_len, dim)
-        output = F.tanh(self.linear_out(combined.view(-1, 2 * hidden_size))).view(batch_size, -1, hidden_size)
+        output = torch.tanh(self.linear_out(combined.view(-1, 2 * hidden_size))).view(batch_size, -1, hidden_size)
 
         return output, attn


### PR DESCRIPTION
torch.nn.functional.tanh is depreciated. I replaced this line (F.tanh in this case) with the preferred method, torch.tanh

see pytotch documentation on the subject [here](https://pytorch.org/docs/stable/torch.html?highlight=torch%20tanh#torch.tanh)