### PR TITLE
replace size_average param

### DIFF
--- a/seq2seq/loss/loss.py
+++ b/seq2seq/loss/loss.py
@@ -91,9 +91,9 @@ class NLLLoss(Loss):
 
     _NAME = "Avg NLLLoss"
 
-    def __init__(self, weight=None, mask=None, size_average=True):
+    def __init__(self, weight=None, mask=None, reduction='mean'):
         self.mask = mask
-        self.size_average = size_average
+        self.reduction = reduction
         if mask is not None:
             if weight is None:
                 raise ValueError("Must provide weight with a mask.")
@@ -101,14 +101,14 @@ class NLLLoss(Loss):
 
         super(NLLLoss, self).__init__(
             self._NAME,
-            nn.NLLLoss(weight=weight, size_average=size_average))
+            nn.NLLLoss(weight=weight, reduction=reduction))
 
     def get_loss(self):
         if isinstance(self.acc_loss, int):
             return 0
         # total loss for all batches
         loss = self.acc_loss.data.item()
-        if self.size_average:
+        if self.reduction:
             # average loss per batch
             loss /= self.norm_term
         return loss
@@ -132,7 +132,7 @@ class Perplexity(NLLLoss):
     _MAX_EXP = 100
 
     def __init__(self, weight=None, mask=None):
-        super(Perplexity, self).__init__(weight=weight, mask=mask, size_average=False)
+        super(Perplexity, self).__init__(weight=weight, mask=mask, reduction='sum')
 
     def eval_batch(self, outputs, target):
         self.acc_loss += self.criterion(outputs, target)

--- a/seq2seq/loss/loss.py
+++ b/seq2seq/loss/loss.py
@@ -86,7 +86,7 @@ class NLLLoss(Loss):
     Args:
         weight (torch.Tensor, optional): refer to http://pytorch.org/docs/master/nn.html#nllloss
         mask (int, optional): index of masked token, i.e. weight[mask] = 0.
-        size_average (bool, optional): refer to http://pytorch.org/docs/master/nn.html#nllloss
+        reduction (string, optional): refer to https://pytorch.org/docs/master/nn.html#nllloss
     """
 
     _NAME = "Avg NLLLoss"

--- a/tests/test_loss_loss.py
+++ b/tests/test_loss_loss.py
@@ -57,9 +57,9 @@ class TestLoss(unittest.TestCase):
         self.assertAlmostEqual(loss_val, pytorch_loss.item())
 
     def test_nllloss_WITH_OUT_SIZE_AVERAGE(self):
-        loss = NLLLoss(size_average=False)
+        loss = NLLLoss(reduction='sum')
         pytorch_loss = 0
-        pytorch_criterion = torch.nn.NLLLoss(size_average=False)
+        pytorch_criterion = torch.nn.NLLLoss(reduction='sum')
         for output, target in zip(self.outputs, self.targets):
             loss.eval_batch(output, target)
             pytorch_loss += pytorch_criterion(output, target)


### PR DESCRIPTION
The size_average parameter is being depreciated. The preferred way to handle loss summation/averaging is now:

size_average=True => reduction='mean'
size_average=False => reduction='false'

documentation is [here](https://pytorch.org/docs/stable/nn.html?highlight=nll%20loss#torch.nn.NLLLoss)